### PR TITLE
Escape special characters in LDAP filter

### DIFF
--- a/Snapshots/LDAP/lib/SessionTutorial/Controller/Tutorial.pm
+++ b/Snapshots/LDAP/lib/SessionTutorial/Controller/Tutorial.pm
@@ -57,6 +57,8 @@ sub check_credentials {
   my $ldap = Net::LDAP->new( $LDAP_server )
         or warn("Couldn't connect to LDAP server $LDAP_server: $@"), return;
 
+  # Escape special chacarters in the username
+  $username =~ s/([*()\\\x{0}])/sprintf '\\%02x', ord($1)/ge;
   my $search = $ldap->search( base => $base_DN,
                               filter => "$user_attr=$username",
                               attrs => [$user_id],

--- a/Snapshots/Logging/lib/SessionTutorial/Controller/Tutorial.pm
+++ b/Snapshots/Logging/lib/SessionTutorial/Controller/Tutorial.pm
@@ -64,6 +64,8 @@ sub check_credentials {
   my $ldap = Net::LDAP->new( $LDAP_server )
         or warn("Couldn't connect to LDAP server $LDAP_server: $@"), return;
 
+  # Escape special chacarters in the username
+  $username =~ s/([*()\\\x{0}])/sprintf '\\%02x', ord($1)/ge;
   my $search = $ldap->search( base => $base_DN,
                               filter => "$user_attr=$username",
                               attrs => [$user_id],

--- a/Snapshots/Redirect/lib/SessionTutorial/Controller/Tutorial.pm
+++ b/Snapshots/Redirect/lib/SessionTutorial/Controller/Tutorial.pm
@@ -65,6 +65,8 @@ sub check_credentials {
   my $ldap = Net::LDAP->new( $LDAP_server )
         or warn("Couldn't connect to LDAP server $LDAP_server: $@"), return;
 
+  # Escape special chacarters in the username
+  $username =~ s/([*()\\\x{0}])/sprintf '\\%02x', ord($1)/ge;
   my $search = $ldap->search( base => $base_DN,
                               filter => "$user_attr=$username",
                               attrs => [$user_id],

--- a/Snapshots/Templates/lib/SessionTutorial/Controller/Tutorial.pm
+++ b/Snapshots/Templates/lib/SessionTutorial/Controller/Tutorial.pm
@@ -64,6 +64,8 @@ sub check_credentials {
   my $ldap = Net::LDAP->new( $LDAP_server )
         or warn("Couldn't connect to LDAP server $LDAP_server: $@"), return;
 
+  # Escape special chacarters in the username
+  $username =~ s/([*()\\\x{0}])/sprintf '\\%02x', ord($1)/ge;
   my $search = $ldap->search( base => $base_DN,
                               filter => "$user_attr=$username",
                               attrs => [$user_id],

--- a/docs/Advent_calendar/Authenticating_LDAP.md
+++ b/docs/Advent_calendar/Authenticating_LDAP.md
@@ -166,6 +166,8 @@ sub check_credentials {
   my $ldap = Net::LDAP->new( $LDAP_server )
         or warn("Couldn't connect to LDAP server $LDAP_server: $@"), return;
 
+  # Escape special chacarters in the username
+  $username =~ s/([*()\\\x{0}])/sprintf '\\%02x', ord($1)/ge;
   my $search = $ldap->search( base => $base_DN,
                               filter => join('=', $user_attr, $username),
                               attrs => [$user_id],

--- a/docs/LDAP.md
+++ b/docs/LDAP.md
@@ -38,6 +38,8 @@ Replace the body of `check_credentials()` with the following
   my $ldap = Net::LDAP->new( $LDAP_server )
         or warn("Couldn't connect to LDAP server $LDAP_server: $@"), return;
 
+  # Escape special chacarters in the username
+  $username =~ s/([*()\\\x{0}])/sprintf '\\%02x', ord($1)/ge;
   my $search = $ldap->search( base => $base_DN,
                               filter => join('=', $user_attr, $username),
                               attrs => [$user_id],

--- a/old_files/ldap/lib/LDAP/Controller/Login.pm
+++ b/old_files/ldap/lib/LDAP/Controller/Login.pm
@@ -32,6 +32,8 @@ sub check_credentials {
     my $ldap = Net::LDAP->new( $LDAP_server ) 
         or warn("Couldn't connect to LDAP server $LDAP_server: $@"), return;
 
+    # Escape special chacarters in the username
+    $username =~ s/([*()\\\x{0}])/sprintf '\\%02x', ord($1)/ge;
     my $search = $ldap->search( base => $base_DN, 
                         filter => "$user_attr=$username",
                         attrs => [$user_id],

--- a/session_tutorial/lib/SessionTutorial/Controller/Tutorial.pm
+++ b/session_tutorial/lib/SessionTutorial/Controller/Tutorial.pm
@@ -80,6 +80,8 @@ sub check_credentials {
   my $ldap = Net::LDAP->new( $LDAP_server )
         or warn("Couldn't connect to LDAP server $LDAP_server: $@"), return;
 
+  # Escape special chacarters in the username
+  $username =~ s/([*()\\\x{0}])/sprintf '\\%02x', ord($1)/ge;
   my $search = $ldap->search( base => $base_DN,
                               filter => "$user_attr=$username",
                               attrs => [$user_id],


### PR DESCRIPTION
[RFC 4515](https://tools.ietf.org/html/rfc4515#section-3) requires `*` `(` `)` `\` and `NUL` to be escaped with a backslash
followed by the hexadecimal representation of the byte value.

